### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -14,7 +14,7 @@
           - uses: actions/checkout@v2
 
           - name: Run Changelog-CI
-            uses: saadmk11/changelog-ci@v0.8.0
+            uses: saadmk11/changelog-ci@v1.0.0
             env:
               USERNAME:  ${{secrets.USERNAME}}
               EMAIL:  ${{secrets.EMAIL}}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/changelog-ci](https://github.com/saadmk11/changelog-ci)** published a new release [v1.0.0](https://github.com/saadmk11/changelog-ci/releases/tag/v1.0.0) on 2021-10-24T14:09:24Z
