### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yaml
+++ b/.github/workflows/action-updater.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.5.6
+        uses: saadmk11/github-actions-version-updater@v0.7.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release [v0.7.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.0) on 2022-10-22T14:34:54Z
