### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yaml
+++ b/.github/workflows/action-updater.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.0
+        uses: saadmk11/github-actions-version-updater@v0.7.1
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -14,7 +14,7 @@
           - uses: actions/checkout@v2
 
           - name: Run Changelog-CI
-            uses: saadmk11/changelog-ci@v1.0.0
+            uses: saadmk11/changelog-ci@v1.1.0
             env:
               USERNAME:  ${{secrets.USERNAME}}
               EMAIL:  ${{secrets.EMAIL}}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/changelog-ci](https://github.com/saadmk11/changelog-ci)** published a new release **[v1.1.0](https://github.com/saadmk11/changelog-ci/releases/tag/v1.1.0)** on 2022-10-23T12:46:40Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.1)** on 2022-10-29T16:38:42Z
